### PR TITLE
[codex] 修复 SourceBans 分组导入后的运行时刷新

### DIFF
--- a/nonebot_plugin_l4d2_server/presentation/render/image_tools.py
+++ b/nonebot_plugin_l4d2_server/presentation/render/image_tools.py
@@ -139,9 +139,8 @@ class CustomizeImage:
         based_w: int,
         based_h: int,
     ):
-        import logging
-
         from PIL import Image
+        import logging
 
         logger = logging.getLogger(__name__)
 

--- a/nonebot_plugin_l4d2_server/presentation/render/image_tools.py
+++ b/nonebot_plugin_l4d2_server/presentation/render/image_tools.py
@@ -139,8 +139,9 @@ class CustomizeImage:
         based_w: int,
         based_h: int,
     ):
-        from PIL import Image
         import logging
+
+        from PIL import Image
 
         logger = logging.getLogger(__name__)
 

--- a/nonebot_plugin_l4d2_server/server/ban/__init__.py
+++ b/nonebot_plugin_l4d2_server/server/ban/__init__.py
@@ -29,6 +29,14 @@ async def _delete_group_and_page(tag: str) -> tuple[bool, bool]:
     return group_deleted, page_deleted
 
 
+async def _set_group_and_refresh(tag: str, servers):
+    """保存服务器组并立即刷新运行时查询状态。"""
+    path = await set_group(tag, servers)
+    reload_ip()
+    refresh_server_command_rule(l4_request)
+    return path
+
+
 l4_add_ban = on_command("l4_add_ban", aliases={"l4addban", "l4添加组"})
 l4_reload_groups = on_command("l4_reload_groups", aliases={"l4reloadsb", "l4刷新组"})
 l4_list_groups = on_command(
@@ -68,7 +76,7 @@ async def _(args: Message = CommandArg()):
 
     api = L4D2Api()
     server_list = await api.get_sourceban(tag, page)
-    path = await set_group(tag, server_list)
+    path = await _set_group_and_refresh(tag, server_list)
     await UniMessage.text(
         f"✅ 已更新：{path.name}（共 {len(server_list)} 台）",
     ).finish()

--- a/tests/test_server_groups.py
+++ b/tests/test_server_groups.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_set_group_refreshes_runtime_registry(monkeypatch, tmp_path: Path):
+    from nonebot_plugin_l4d2_server.server import ban
+
+    group_path = tmp_path / "云.json"
+    set_group = AsyncMock(return_value=group_path)
+    reload_ip = Mock()
+    refresh_server_command_rule = Mock()
+    servers = ["server.example:27015"]
+
+    monkeypatch.setattr(ban, "set_group", set_group)
+    monkeypatch.setattr(ban, "reload_ip", reload_ip)
+    monkeypatch.setattr(
+        ban,
+        "refresh_server_command_rule",
+        refresh_server_command_rule,
+    )
+
+    result = await ban._set_group_and_refresh("云", servers)  # noqa: SLF001
+
+    assert result == group_path
+    set_group.assert_awaited_once_with("云", servers)
+    reload_ip.assert_called_once_with()
+    refresh_server_command_rule.assert_called_once_with(ban.l4_request)


### PR DESCRIPTION
## 问题

`l4addban` 抓取 SourceBans 页面并写入分组文件后，没有刷新运行时的 `ALLHOST` 和命令规则。因此命令会报告成功导入服务器数量，但立即查询新分组时仍可能返回“服务器无响应”，必须执行 `l4reloadsb` 或重启插件后才能使用。

这个问题源自 #71 引入的分组保存流程，后续重构中仍然保留。

## 修改

- 新增保存并刷新运行时状态的辅助函数。
- `l4addban` 写入分组后立即调用 `reload_ip()`。
- 同步调用 `refresh_server_command_rule(l4_request)`，让新增分组命令无需重启即可生效。
- 添加回归测试，验证保存、内存刷新和命令规则刷新都会执行。
- pre-commit.ci 自动整理了 `presentation/render/image_tools.py` 中一处既有的局部 import 顺序；不涉及行为变更。

## 影响

执行以下命令后可以立即使用 `云` 查询，无需额外重载或重启：

```text
l4addban 云 https://anne.trygek.com/bans/index.php?p=servers
云
```

## 验证

- `pytest -q tests/test_server_groups.py`：1 passed
- `ruff check`（改动文件）：通过
- `ruff format --check`（改动文件）：通过
- `git diff --check`：通过

完整测试集中的既有 `tests/test_init.py` 使用了不存在的相对模块路径；仓库级 Ruff 在 pre-commit 自动修复 import 后仍有 12 个与本次改动无关的基线错误。本 PR 未扩展处理这些既有问题。
